### PR TITLE
Update Gemfile ruby version quotes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby ‘2.3.0’
+ruby '2.3.0'
 gem 'rails', '4.2.5'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'


### PR DESCRIPTION
Hi,

I had to fix quotes around the ruby version to get bundler working to install dependencies, now using single quotes.
I'm using rbenv on Mac OS X 10.10