### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your Learn Rails project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start Learn Rails via "Run > Start Learn Rails"
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/README.textile
+++ b/README.textile
@@ -114,6 +114,14 @@ $ git clone git://github.com/RailsApps/learn-rails.git
 
 You'll need "git":http://git-scm.com/ on your machine. See "Rails and Git":http://railsapps.github.io/rails-git.html.
 
+h4. Nitrous Quickstart
+
+If you don't want to go through the hassle of installing things on your personal machine, you can quickly create a free learn-rails development environment in the cloud on Nitrous:
+
+!{width:142px; height: 34px}https://nitrous-image-icons.s3.amazonaws.com/quickstart.png(Nitrous Quickstart)!:https://www.nitrous.io/quickstart
+
+In the IDE, start Learn Rails via @Run > Start Learn Rails@ and access your site via @Preview > 3000@.
+
 h4. Generate
 
 If you want to use the project as a starter application, use the "Rails Composer":http://railsapps.github.io/rails-composer/ tool to generate a new version of the example app. You'll be able to give it your own project name when you generate the app. Generating the application gives you additional options.

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "rails",
+  "ports": [3000],
+  "name": "Learn Rails",
+  "description": "A Rails 4.2 example application to accompany the book 'Learn Ruby on Rails'.",
+  "scripts": {
+    "post-create": "rm -rf ~/code/example && rbenv install 2.3.0 && rbenv global 2.3.0 && gem install bundle && cd ~/code/learn-rails && bundle install",
+    "Start Learn Rails": "cd ~/code/learn-rails && rails s -b 0.0.0.0"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.